### PR TITLE
update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "cesium": "^1.17.0",
     "jsdoc": "^3.4.0",
     "openlayers": "^3.18.1",
-    "typescript": "^1.8.2"
+    "typescript": "^2.0.3"
   }
 }


### PR DESCRIPTION
Fixes bug: Building from source throws "error TS5023: Unknown compiler option 'lib'."

'lib' was introduced with TypeScript 2.
